### PR TITLE
Added workflow to publish to npm and git on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish Package (github and npm)
+
+on:
+    push:
+        tags:
+            - "v*"
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v4
+
+            - name: Set up Node
+              uses: actions/setup-node@v4
+              with:
+                node-version: 18
+                registry-url: 'https://registry.npmjs.org/'
+
+            - name: Install Dependencies
+              run: npm ci
+
+            - name: Publish to npmjs
+              env: 
+                NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+              run: npm publish --access public
+
+            - name: Publish to git
+              env:
+                NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                npm config set registry https://npm.pkg.github.com/
+                npm publish

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/CapybaraIcons/orange-icons#readme",
   "publishConfig": {
-    "access": "public",
-    "registry": "https://npm.pkg.github.com/"
+    "access": "public"
   }
 }


### PR DESCRIPTION
npm registry has not been updated, as the registry was set to github's. This PR adds a github workflow, in order to publish to both registries simultaneously upon pushing a new version tag. The correct secrets need to be in place before usage.